### PR TITLE
Add Gradle setup instructions, overhaul README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,32 @@
+# kotlinx-nodejs
+
+[![kotlinx-nodejs on Bintray](https://img.shields.io/bintray/v/kotlin/kotlinx/kotlinx.nodejs)](https://bintray.com/kotlin/kotlinx/kotlinx.nodejs)
 [![JetBrains incubator project](https://jb.gg/badges/incubator.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+Gi^tHub)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 
-# About kotlinx-nodejs
-This repository contains a source set of kotlin [external declarations](https://kotlinlang.org/docs/reference/js-interop.html) for using nodejs
-API for a Kotlin JavaScript target. 
+`kotlinx-nodejs` provides Kotlin [external declarations](https://kotlinlang.org/docs/reference/js-interop.html) for using the [Node.js API](https://nodejs.org/docs/latest/api/) from Kotlin code targeting JavaScript. 
 
-# Current state 
-Right now the only thing we guarantee is that the provided source set is compiling. There can be, unfortunately, 
-some inconsistent declarations, missing declarations, redundant declarations or even unusable ones.
+## We're currently in preview!
+**Right now the only thing we guarantee is that the provided source set is compiling.** There can be, unfortunately, 
+some inconsistent, missing, redundant, or even unusable declarations.
  
-Feel free to create any issues and bug reports and they will be addressed as soon as possible. 
-Keep in mind that these sources are generated with [Dukat](https://github.com/Kotlin/dukat) and **are not supposed to be edited manually**.
-So it makes not much of a sense to create a PR with suggested improvements but rather to discuss in an issue
-what these particular improvements supposed to be. 
+Feel free to submit [issues and bug reports](https://github.com/Kotlin/kotlinx-nodejs/issues) as you encounter them. We will do our best to address them as soon as possible.
 
 
+Keep in mind that these sources are generated with [Dukat](https://github.com/Kotlin/dukat) and **are not supposed to be edited manually**. Please do not send pull requests to this repository directly. Instead, please file an issue about the improvements you have in mind – we can then adjust the generator tool accordingly.
 
+## Setup
+To add `kotlinx-nodejs` to your project, make sure you have bintray added to your repositories. You can then add a dependency:
 
- 
+```kotlin
+repositories {
+    // . . .
+    jcenter()
+}
+
+dependencies {
+    // . . .
+    implementation("org.jetbrains.kotlinx:kotlinx-nodejs:0.0.3")
+}
+```
+


### PR DESCRIPTION
This PR adds setup instructions with Gradle for the (current) latest version of kotlinx-nodejs.
I've also reworded some parts of the surrounding text to make it easier for folks to see the current state of the project at a glance.